### PR TITLE
Fix missing commas

### DIFF
--- a/lib/favicons-middleware.js
+++ b/lib/favicons-middleware.js
@@ -26,9 +26,9 @@ module.exports = function favicons(dir, opts) {
     'apple-touch-icon-120x120.png',
     'apple-touch-icon-120x120-precomposed.png',
     'apple-touch-icon-144x144.png',
-    'apple-touch-icon-144x144-precomposed.png'
+    'apple-touch-icon-144x144-precomposed.png',
     'apple-touch-icon-152x152.png',
-    'apple-touch-icon-152x152-precomposed.png'
+    'apple-touch-icon-152x152-precomposed.png',
     'apple-touch-icon-180x180.png',
     'apple-touch-icon-180x180-precomposed.png',
     'touch-icon-192x192.png'


### PR DESCRIPTION
This will fix missing commas in the `readFilenames` array that was causing an `SyntaxError: Unexpected string` error on lines 30 and 32.
